### PR TITLE
[FEATURE] Add session-report page for use by itemsapi_adaptive

### DIFF
--- a/www/analytics/reports/session-detail.php
+++ b/www/analytics/reports/session-detail.php
@@ -5,6 +5,14 @@ include_once 'includes/header.php';
 
 use LearnositySdk\Request\Init;
 
+if ($_GET["session_id"]) {
+    $session_id = $_GET["session_id"];
+} elseif ($_POST["session_id"]) {
+    $session_id = $_POST["session_id"];
+} else {
+    $session_id = 'fd09e334-875f-42c1-838c-aa90aba2bab1';
+}
+
 $security = array(
     'consumer_key' => $consumer_key,
     'domain'       => $domain
@@ -15,8 +23,8 @@ $request = array(
         array(
             'id'         => 'report-detail',
             'type'       => 'session-detail-by-item',
-            'user_id'    => 'demo_student',
-            'session_id' => 'fd09e334-875f-42c1-838c-aa90aba2bab1'
+            'user_id'    => $studentid,
+            'session_id' => $session_id,
         )
     ),
     'configuration' => array(

--- a/www/analytics/reports/session-report.php
+++ b/www/analytics/reports/session-report.php
@@ -1,0 +1,88 @@
+<?php
+
+include_once '../../config.php';
+include_once 'includes/header.php';
+
+use LearnositySdk\Request\Init;
+use LearnositySdk\Request\DataApi;
+
+if ($_GET["session_id"]) {
+    $session_id = $_GET["session_id"];
+} elseif ($_POST["session_id"]) {
+    $session_id = $_POST["session_id"];
+}
+
+$security = array(
+    'consumer_key' => $consumer_key,
+    'domain'       => $domain
+);
+
+$reportsRequest = [ 'reports' =>
+    $reports = [
+        [
+            'id' => 'sessions-summary-div',
+            'type' => 'session-summary',
+            'user_id' => $studentid,
+            'session_ids' => [ $session_id ],
+        ],
+        [
+            'id' => 'session-detail-by-item-div',
+            'type' => 'session-detail-by-item',
+            'user_id' => $studentid,
+            'session_id' => $session_id,
+        ],
+    ],
+];
+
+$reportsInit = new Init('reports', $security, $consumer_secret, $reportsRequest);
+$signedRequest = $reportsInit->generate();
+
+?>
+
+<div class="jumbotron section">
+    <div class="overview">
+        <h1 id="session-head">Session Report</h1>
+<?php if (isset($session_id)) { ?>
+        <p>Report for session <?php print($session_id); ?></p>
+<?php } else { ?>
+        <p>Use this page to look-up the report for an existing session.<p>
+        <form>
+            <label for="session_id">Session ID:</label>
+            <input name="session_id">
+            <input type="submit" value="Get report">
+        </form>
+<?php } ?>
+    </div>
+</div>
+
+<?php if (isset($session_id)) { ?>
+<div class="section">
+<h2>Session summary</h2>
+<div id="sessions-summary-div"></div>
+</div>
+
+<div class="section">
+<h2>Detailed report by question (Reports API)</h2>
+<div id="session-detail-by-item-div"></div>
+</div>
+
+<script src="<?php echo $url_reports; ?>"></script>
+
+<script>
+var initOpts = <?php echo $signedRequest ?>;
+var reportsApp = LearnosityReports.init(initOpts);
+function onReportsReady() {
+    var sessList = reportsApp.getReport("other-sessions");
+    sessList.on('click:session', function (data) {
+        console.log(
+            'A session in the report was clicked: ' + data.session_id
+        );
+        window.location = window.location.protocol + "//" + window.location.host + window.location.pathname +  "?studentid=<?php print($studentid); ?>&sessid=" + data.session_id;
+    });
+}
+</script>
+<?php } ?>
+
+<?php
+    include_once 'views/modals/initialisation-preview.php';
+    include_once 'includes/footer.php';

--- a/www/assessment/items/itemsapi_adaptive.php
+++ b/www/assessment/items/itemsapi_adaptive.php
@@ -6,6 +6,8 @@ include_once 'includes/header.php';
 use LearnositySdk\Request\Init;
 use LearnositySdk\Utils\Uuid;
 
+$session_id = Uuid::generate();
+
 $security = array(
     'consumer_key' => $consumer_key,
     'domain'       => $domain
@@ -16,7 +18,7 @@ $request = array(
     'name'           => 'Items API demo - adaptive activity',
     'rendering_type' => 'assess',
     'state'          => 'initial',
-    'session_id'     => Uuid::generate(),
+    'session_id'     => $session_id,
     'user_id'        => $studentid,
     'assess_inline'  => true,
     'adaptive'       => array(
@@ -58,7 +60,7 @@ $request = array(
         ),
         'assessApiVersion'    => "latest",
         'configuration'       => array(
-            'onsubmit_redirect_url' => 'itemsapi_adaptive.php',
+            'onsubmit_redirect_url' => '../../analytics/reports/session-report.php?session_id=' . $session_id,
             'onsave_redirect_url'   => 'itemsapi_adaptive.php'
         )
     )
@@ -99,6 +101,7 @@ $signedRequest = $Init->generate();
     </div>
     <h1>Items API – Adaptive Assessment</h1>
     <p>A dynamic assessment that adapts to the user's ability in real time.<p>
+    <p>Your session ID is <?php print($session_id)?>.</p>
 </div>
 
 <div class="section">


### PR DESCRIPTION
The page takes `session_id` as a parameter, or displays a simple form to
enter it if missing.

This also adds the same logic to the existing session-detail page,
without the form.

Signed-off-by: Olivier Mehani olivier.mehani@learnosity.com
