### PR TITLE
Use $domain rather than $_SERVER['SERVER_NAME']

### DIFF
--- a/www/authoring/questioneditor/algorithmicMath/demo.php
+++ b/www/authoring/questioneditor/algorithmicMath/demo.php
@@ -1,5 +1,6 @@
 <?php
-$host = $_SERVER['HTTP_HOST'];
+include_once '../../../../config.php';
+
 $version = '1.0.0';
 $versionPath = 'dev';
 
@@ -56,7 +57,7 @@ if ($version !== 'dev') {
 
         <!-- EXAMPLE -->
         <script>
-            var domain = '<?php echo $host; ?>';
+            var domain = '<?php echo $domain; ?>';
             var versionPath = '<?php echo $versionPath; ?>';
         </script>
 

--- a/www/casestudies/customquestions/custom.php
+++ b/www/casestudies/customquestions/custom.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/casestudies/customquestions/custom_box_whisker.php
+++ b/www/casestudies/customquestions/custom_box_whisker.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/casestudies/customquestions/custom_mathcore.php
+++ b/www/casestudies/customquestions/custom_mathcore.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/casestudies/customquestions/custom_percentage_bar.php
+++ b/www/casestudies/customquestions/custom_percentage_bar.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/casestudies/customquestions/custom_shorttext.php
+++ b/www/casestudies/customquestions/custom_shorttext.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/casestudies/customquestions/custom_shorttext_authoring.php
+++ b/www/casestudies/customquestions/custom_shorttext_authoring.php
@@ -10,7 +10,7 @@ $session_id = Uuid::generate();
 
 $security = [
     'user_id'      => $studentid,
-    'domain'       => $_SERVER['SERVER_NAME'],
+    'domain'       => $domain,
     'consumer_key' => $consumer_key
 ];
 

--- a/www/config.php
+++ b/www/config.php
@@ -14,7 +14,15 @@ $consumer_key = 'yis0TYCu7U9V4o7M';
 // Note - Consumer secret should never get displayed on the page - only used for creation of signature server side
 $consumer_secret = '74c5fd430cf1242a527f6223aebd42d30464be22';
 
-// Some products need the domain as part of the security signature. Demos has been tested on "localhost"
+// Some products need the domain (and domain only: no port number) as part of the security signature.
+//
+// Note that using SERVER_NAME may cause issues leading to signature mismatches if SERVER_NAME differs from the name
+// the client is using to access the server, as is the case when using aliases. In this case, using HTTP_HOST may address the issue
+// This comes with the caveat that HTTP_HOST contains the port used by the client, if non-standard, which will also
+// break the signature. If using server aliases on non-standard port, it will be necessary to trim the HTTP_HOST value
+// after the last colon (:), to remove the port number.
+//
+// Demos has been tested on "localhost"
 $domain = $_SERVER['SERVER_NAME'];
 
 // Generate timestamp in format YYYYMMDD-HHMM for use in signature


### PR DESCRIPTION
`$domain` is defined to `$_SERVER['SERVER_NAME']` value in `www/config.php`,
where it can be easily overriden for all the demos at once.

This makes it easier to prevent signature mismatches when using a DNS
name different from the server's name.

LRN-19805

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>