### PR TITLE
[FEATURE] PHP-only composer installer with hash verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 .vagrant
 www/config_override*
 node_modules
+composer-setup.php
 composer.phar
 ._*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PHP=php
+
 all: run-php
 
 lint:
@@ -10,7 +12,7 @@ all: run-composer
 
 get-composer: composer.phar
 composer.phar:
-	./get-composer.sh
+	$(PHP) get-composer.php
 
 run-composer: composer.phar
 	./composer.phar --no-interaction install

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ previous sections.
 Note that the `make`-based instructions in the “Getting Started” section take
 care of the following for you.
 
-For simplicity, the `get-composer.sh` script can be used to fetch a
+For simplicity, the `get-composer.php` script can be used to fetch a
 local version of composer. It will be named `composer.phar`, and will have to be
 called as `./composer.phar` instead of just `composer`.
 

--- a/get-composer.php
+++ b/get-composer.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+# Adapted from https://getcomposer.org
+#
+$installerUrl = 'https://getcomposer.org/installer';
+$installerSigUrl = 'https://composer.github.io/installer.sig';
+$installerScript = 'composer-setup.php';
+
+print("Downloading installer from {$installerUrl} ..." . PHP_EOL);
+copy($installerUrl, $installerScript);
+
+print("Getting hash from {$installerSigUrl} ... ");
+$expectedHash = trim(file_get_contents($installerSigUrl));
+print($expectedHash . PHP_EOL);
+
+$installerHash = hash_file('SHA384', $installerScript);
+if ("$installerHash" === "$expectedHash") {
+    print('Installer verified; installing ...' . PHP_EOL);
+    include $installerScript;
+} else {
+    print("Installer corrupt, hash does not match: $installerHash; aborting." . PHP_EOL);
+}
+
+unlink($installerScript);

--- a/get-composer.sh
+++ b/get-composer.sh
@@ -1,7 +1,3 @@
-#!/bin/sh -x
-# From https://getcomposer.org
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-php composer-setup.php
-
-rm composer-setup.php
+#!/bin/sh
+echo "\\033[01;31mWARNING: ${0} is deprecated; please use \`php get-composer.php\` instead.\\033[0m" >&2
+php get-composer.php


### PR DESCRIPTION
This PR replaces `get-composer.sh` (and its dependency on a POSIX shell) with a plain PHP `get-composer.php` (a placeholder `get-composer.sh` is left behind with a warning for backward compatibility)

It also fetches the expected hash from github.io (while the installer itself comes from getcomposer.org

* Pros:
  * no assumption of running on a UNIX system
  * we always get and check the latest version; 
* Cons:
  * If both getcomposer.com and github.io get compromised, we won't be able to detect it

Signed-off-by: Olivier Mehani <olivier.mehani@learnosity.com>