### PR TITLE
Adds support for the Learnosity Developer Environment for internal usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+
+services:
+    web:
+        image: nginx:latest
+        volumes:
+            - .:/srv/site/demos:z
+            - ./lde_config/nginx_site.conf:/etc/nginx/conf.d/default.conf:z
+        networks:
+            - net
+            - lde_net
+        labels:
+            - "learnosity.app_name=site-demos"
+            - "learnosity.app_root=${COMPOSE_ROOT}"
+            - "traefik.frontend.rule=Host:demos.dev.learnosity.com"
+            - "traefik.port=80"
+            - "traefik.enable=true"
+        depends_on:
+            - php-fpm
+
+    php-fpm:
+        image: php:7.2-fpm
+        volumes:
+            - .:/srv/site/demos:z
+        networks:
+            - net
+            - lde_internal
+        dns:
+            - 192.168.199.3
+
+networks:
+    net:
+    lde_net:
+        external: true
+    lde_internal:
+        external: true

--- a/lde_config/nginx_site.conf
+++ b/lde_config/nginx_site.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /srv/site/demos/www;
+
+    location = / {
+        index index.php;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php-fpm:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}
+


### PR DESCRIPTION
This PR adds support for `lde` to run the demos. I includes the necessary files to stand up a docker-compose configuration that is compatible with our internal Traefik based LDE.