### PR TITLE
[FEATURE] Adding support for custom page titles

### DIFF
--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -1,8 +1,13 @@
+<?php
+if (!isset($pageTitle)) {
+    $pageTitle = 'Learnosity Demos';
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Learnosity Demos</title>
+    <title><?= $pageTitle; ?></title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="<?php echo $env['www'] ?>static/images/favicon.ico?<?php echo $assetVersion ?>" type="image/x-icon">

--- a/www/authoring/rtl.php
+++ b/www/authoring/rtl.php
@@ -4,6 +4,7 @@
 include_once '../env_config.php';
 
 //site scaffolding
+$pageTitle = 'Learnosity Author - Right-to-Left Language Support';
 include_once 'includes/header.php';
 
 //common Learnosity config elements including API version control vars

--- a/www/custom_404.php
+++ b/www/custom_404.php
@@ -1,4 +1,6 @@
 <?php
+$pageTitle = '404 Page Not Found';
+
 include_once 'env_config.php';
 include_once 'includes/mapping.php';
 include_once 'includes/header.php';


### PR DESCRIPTION
Currently we don't support custom page titles, instead we use the
default 'Learnosity Demos' on every page. This hurts at SEO but
also prevents us from filtering 404s in Google Analytics etc.