### PR TITLE
[FEATURE] Allow to specify the port to use when running the local PHP…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PHP=php
+PORT=8080
 
 all: run-php
 
@@ -12,13 +13,13 @@ all: run-composer
 
 get-composer: composer.phar
 composer.phar:
-	$(PHP) get-composer.php
+	${PHP} get-composer.php
 
 run-composer: composer.phar
 	./composer.phar --no-interaction install
 
 run-php: run-composer
-	php -S localhost:8080 --docroot www
+	php -S localhost:${PORT} --docroot www
 
 run-vagrant:
 	vagrant up

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ fine but the internal security in some of the APIs is domain restricted. So
 until you contact Learnosity to whitelist specific domains, access is restricted
 to *localhost*.
 
+If port 8080 is already in use, you can specify a custom port instead, with
+
+    make run-php PORT=8000  # Using custom port 8000
+
+You would then be able visit http://localhost:8000 in a browser.
+
 ### Using PHP's native server
 
 You can use PHP's built-in server to quickly get up and running.


### PR DESCRIPTION
… server

Use

    make run-php PORT=8000

This is useful when you already have something running on the default port 8080.