### PR TITLE
[FEATURE] Implement Cookiebot banner and remove legacy cookie banner

### DIFF
--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -14,12 +14,7 @@
                 <a href="https://reference.learnosity.com">API Reference</a>
                 <a href="https://status.learnosity.com">API Status</a>
                 <a href="https://learnosity.com">Visit Learnosity</a>
-                <?php
-                if ($_SERVER['REQUEST_URI'] == "/")
-                {
-                    echo '<a href="/?resetConsent=true">Reset Cookies</a>';
-                }
-                ?>
+                <a href="/cookie-policy/index.php">Cookie Policy</a>
             </div>
         </div>
     </div>

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -14,6 +14,8 @@ if (!isset($pageTitle)) {
             cb.setAttribute('data-cbid', '7d32057a-6a03-459f-84db-e232787c5485');
             cb.setAttribute('data-blockingmode', 'auto');
             cb.type = 'text/javascript';
+            // Only load GTM if Cookiebot has consented which needs to be done in the onload event
+            // as the Cookiebot script is async and we need to wait for it to load
             cb.onload = function () {  
                 if (window?.Cookiebot?.consented) {  
                     (function(w,d,s,l,i){  

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -14,6 +14,22 @@ if (!isset($pageTitle)) {
             cb.setAttribute('data-cbid', '7d32057a-6a03-459f-84db-e232787c5485');
             cb.setAttribute('data-blockingmode', 'auto');
             cb.type = 'text/javascript';
+            cb.onload = function () {  
+                if (window?.Cookiebot?.consented &&  
+                    location.hostname.endsWith('.learnosity.com')) {  
+                    console.log('in');  
+                    (function(w,d,s,l,i){  
+                        w[l] = w[l] || [];  
+                        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});  
+                        var f = d.getElementsByTagName(s)[0],  
+                            j = d.createElement(s),  
+                            dl = l !== 'dataLayer' ? '&l=' + l : '';  
+                        j.async = true;  
+                        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;  
+                        f.parentNode.insertBefore(j, f);  
+                    })(window, document, 'script', 'dataLayer', 'GTM-M2HXW6');  
+                }  
+            };  
             document.head.appendChild(cb);
         }
     </script><meta charset="utf-8">
@@ -25,22 +41,6 @@ if (!isset($pageTitle)) {
     <script src="/static/dist/all.min.js?<?php echo $assetVersion ?>"></script>
 </head>
 <body>
-
-<script>
-if (window?.Cookiebot?.consented &&
-    location.hostname.endsWith('.learnosity.com')) {
-    (function(w,d,s,l,i){
-        w[l] = w[l] || [];
-        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
-        var f = d.getElementsByTagName(s)[0],
-            j = d.createElement(s),
-            dl = l !== 'dataLayer' ? '&l=' + l : '';
-        j.async = true;
-        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-        f.parentNode.insertBefore(j, f);
-    })(window, document, 'script', 'dataLayer', 'GTM-M2HXW6');
-}
-</script>
 
 <?php
     $server_name = filter_input(INPUT_SERVER, 'SERVER_NAME', FILTER_SANITIZE_FULL_SPECIAL_CHARS);

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -15,9 +15,7 @@ if (!isset($pageTitle)) {
             cb.setAttribute('data-blockingmode', 'auto');
             cb.type = 'text/javascript';
             cb.onload = function () {  
-                if (window?.Cookiebot?.consented &&  
-                    location.hostname.endsWith('.learnosity.com')) {  
-                    console.log('in');  
+                if (window?.Cookiebot?.consented) {  
                     (function(w,d,s,l,i){  
                         w[l] = w[l] || [];  
                         w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});  

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -6,7 +6,17 @@ if (!isset($pageTitle)) {
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
+    <script>
+        if (location.hostname.endsWith('.learnosity.com')) {
+            var cb = document.createElement('script');
+            cb.id = 'Cookiebot';
+            cb.src = 'https://consent.cookiebot.com/uc.js';
+            cb.setAttribute('data-cbid', '7d32057a-6a03-459f-84db-e232787c5485');
+            cb.setAttribute('data-blockingmode', 'auto');
+            cb.type = 'text/javascript';
+            document.head.appendChild(cb);
+        }
+    </script><meta charset="utf-8">
     <title><?= $pageTitle; ?></title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,21 +27,19 @@ if (!isset($pageTitle)) {
 <body>
 
 <script>
-
-  const cookieBanner = new CookieBanner();
-  const cookiePreference = cookieBanner.getCookiePreference();
-
-  // If cookiePreference is set to true or is undefined, load the GA Tag Manager
-  if (cookiePreference === 'true' || cookiePreference === undefined) {
-
-    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-M2HXW6');
-
-  }
-
+if (window?.Cookiebot?.consented &&
+    location.hostname.endsWith('.learnosity.com')) {
+    (function(w,d,s,l,i){
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l !== 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-M2HXW6');
+}
 </script>
 
 <?php

--- a/www/cookie-policy/index.php
+++ b/www/cookie-policy/index.php
@@ -1,0 +1,21 @@
+<?php
+
+    include_once '../env_config.php';
+    include_once 'includes/header.php';
+?>
+
+<div class="jumbotron section index">
+    <h1>Learnosity Demos - Cookie Policy</h1>
+
+    <p>When you visit Learnosity Demos website, the website asks your browser to install a small text file which contains a small piece of information (“a cookie”) on your device, which helps you more efficiently browse our website, collect information about website usage and performance and facilitate targeted messaging and marketing.</p>
+    <p>This Cookie Policy describes how Learnosity uses different types of cookies on our site and what control you have over it.</p>
+    <p>Some cookies are strictly necessary for the operation of the site and these cannot be switched off. For other types of cookies, we need your permission and therefore, no other types of cookies will be set on your device unless you have accepted them.</p>
+    <p>The full list of cookies Learnosity may use for the defined purposes is presented below. Some cookies may also be placed by third party services that appear on our pages, which are cookies from a domain different than Learnosity.</p>
+    <p>You can at any time change or withdraw your consent for cookies that are not strictly necessary by changing your browser settings so that cookies from this website cannot be placed on your device.</p>
+    <p>Learn more about who we are, how you can contact us and how we process personal data in our Privacy Policy. Third party sites have their own privacy and cookie policies which Learnosity does not control and you should check with those third parties regarding cookie settings on their sites.</p>
+    
+    <script id="CookieDeclaration" src="https://consent.cookiebot.com/7d32057a-6a03-459f-84db-e232787c5485/cd.js" type="text/javascript" async></script>
+
+</div>
+
+<?php include_once 'includes/footer.php';


### PR DESCRIPTION
This pull request adds a new Cookie Policy page and updates the site to use the Cookiebot consent script instead of the previous internal Learnosity cookie banner.

The Cookiebot script and Google Tag Manager are now only loaded when the site is served from a Learnosity domain