### PR TITLE
Revert "[DOC] removing distractor reduction panel"

### DIFF
--- a/www/assessment/index.php
+++ b/www/assessment/index.php
@@ -389,6 +389,19 @@ include_once 'includes/header.php';
                 </div>
             </div>
         </div>
+        <div class="col-md-6">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Distractor Reduction</h3>
+                </div>
+                <div class="panel-body">
+                    <p>Reduce the number of distractors in multiple choice questions for certain learners as part of your Individual Learning Plan.</p>
+                    <p class="text-right">
+                        <a class="demo_link" href="./distractor-reduction.php">Demo</a>
+                    </p>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
This adds a panel to assessment demos index linking to the distractor reduction page.

This should be merged for the v2026.1.LTS release - Feb 11th.
